### PR TITLE
convert -> magick for windows

### DIFF
--- a/src/Reel.jl
+++ b/src/Reel.jl
@@ -68,9 +68,9 @@ function write(f::String, frames::Frames{M}; fps=frames.fps) where M
         # The maximum delay widely supported by clients is 2 ticks (100 ticks per sec)
         #delay = max(round(100/fps), 2) |> int
         args = reduce(vcat, [[joinpath("$dir", "$i.$ext"), "-delay", "1x$fps", "-alpha", "deactivate"] for i in 1:frames.length])
-        cmd = try read(Sys.isunix() ? `which convert` : `where convert`,String)
+        cmd = try read(Sys.isunix() ? `which convert` : `where magick`,String)
         catch e1
-            try read(Sys.isunix() ? `which convert` : `where convert`,String)
+            try read(Sys.isunix() ? `which convert` : `where magick`,String)
             catch e2
                 error("Could not find imagemagick binary. Is it installed?")
             end
@@ -143,7 +143,7 @@ function show(io::IO, ::MIME"text/html", frames::Frames)
         if frames.rendered != nothing
             if startswith(abspath(frames.rendered), abspath(""))
                 # we can serve it right up from here.
-                file = replace(abspath(frames.rendered), abspath(""), "")
+                file = replace(abspath(frames.rendered), abspath("") => "")
                 writehtml(io, "files/" * file, extension(file))
             else
                 # the file is unreachable to the server, so we symlink or copy it.


### PR DESCRIPTION
Writing to a gif was breaking on windows because `convert` is a windows function and conflicts with image magick `convert`. 

The windows command is `magick`. 

http://www.imagemagick.org/Usage/windows/#convert_issue

https://stackoverflow.com/questions/4481573/how-to-override-windows-convert-command-by-imagemagicks-one
